### PR TITLE
fix OpenOCD debugger issue

### DIFF
--- a/firmware/sound_localizer/CMakeLists.txt
+++ b/firmware/sound_localizer/CMakeLists.txt
@@ -49,7 +49,7 @@ else ()
     add_compile_options(-Og -g)
 endif ()
 
-include_directories(Core/Inc FATFS/Target FATFS/App USB_HOST/App USB_HOST/Target Drivers/STM32F7xx_HAL_Driver/Inc Drivers/STM32F7xx_HAL_Driver/Inc/Legacy Middlewares/Third_Party/FreeRTOS/Source/include Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM7/r0p1 Middlewares/Third_Party/FatFs/src Middlewares/ST/STM32_USB_Host_Library/Core/Inc Middlewares/ST/STM32_USB_Host_Library/Class/CDC/Inc Drivers/CMSIS/Device/ST/STM32F7xx/Include Drivers/CMSIS/Include)
+include_directories(Core/Inc FATFS/Target FATFS/App USB_HOST/App USB_HOST/Target Drivers/STM32F7xx_HAL_Driver/Inc Drivers/STM32F7xx_HAL_Driver/Inc/Legacy Middlewares/Third_Party/FreeRTOS/Source/include Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM7/r0p1 Middlewares/Third_Party/FatFs/src Middlewares/ST/STM32_USB_Host_Library/Core/Inc Middlewares/ST/STM32_USB_Host_Library/Class/CDC/Inc Drivers/CMSIS/Device/ST/STM32F7xx/Include Drivers/CMSIS/Include Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2 Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS)
 
 add_definitions(-DDEBUG -DUSE_HAL_DRIVER -DSTM32F746xx)
 

--- a/firmware/sound_localizer/Core/Src/main.c
+++ b/firmware/sound_localizer/Core/Src/main.c
@@ -163,7 +163,8 @@ int main(void)
   HAL_Init();
 
   /* USER CODE BEGIN Init */
-  
+    DBGMCU->APB1FZ = 1 << 4; // disable timer 6 for debug purposes
+    RCC->CFGR=0; // force HAL_RCC_OscConfig to correctly update RCC (OpenOCD debugger issue)
   /* USER CODE END Init */
 
   /* Configure the system clock */
@@ -203,7 +204,6 @@ int main(void)
   MX_USART6_UART_Init();
   MX_FATFS_Init();
   /* USER CODE BEGIN 2 */
-
   /* USER CODE END 2 */
 
   /* USER CODE BEGIN RTOS_MUTEX */

--- a/firmware/sound_localizer/stm32f746g-disco.cfg
+++ b/firmware/sound_localizer/stm32f746g-disco.cfg
@@ -1,0 +1,69 @@
+# This is an STM32F746G discovery board with a single STM32F746NGH6 chip.
+# http://www.st.com/en/evaluation-tools/32f746gdiscovery.html
+
+# This is for using the onboard STLINK
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+# increase working area to 256KB
+set WORKAREASIZE 0x40000
+
+# enable stmqspi
+set QUADSPI 1
+
+source [find target/stm32f7x.cfg]
+
+# QUADSPI initialization
+proc qspi_init { } {
+	global a
+	mmw 0x40023830 0x000007FF 0				;# RCC_AHB1ENR |= GPIOAEN-GPIOKEN (enable clocks)
+	mmw 0x40023838 0x00000002 0				;# RCC_AHB3ENR |= QSPIEN (enable clock)
+	sleep 1									;# Wait for clock startup
+
+	# PB02: CLK, PB06: BK1_NCS, PD13: BK1_IO3, PE02: BK1_IO2, PD12: BK1_IO1, PD11: BK1_IO0
+
+	# PB06:AF10:V, PB02:AF09:V, PD13:AF09:V, PD12:AF09:V, PD11:AF09:V, PE02:AF09:V
+
+	# Port B: PB06:AF10:V, PB02:AF09:V
+	mmw 0x40020400 0x00002020 0x00001010	;# MODER
+	mmw 0x40020408 0x00003030 0x00000000	;# OSPEEDR
+	mmw 0x40020420 0x0A000900 0x05000600	;# AFRL
+
+	# Port D: PD13:AF09:V, PD12:AF09:V, PD11:AF09:V
+	mmw 0x40020C00 0x0A800000 0x05400000	;# MODER
+	mmw 0x40020C08 0x0FC00000 0x00000000	;# OSPEEDR
+	mmw 0x40020C24 0x00999000 0x00666000	;# AFRH
+
+	# Port E: PE02:AF09:V
+	mmw 0x40021000 0x00000020 0x00000010	;# MODER
+	mmw 0x40021008 0x00000030 0x00000000	;# OSPEEDR
+	mmw 0x40021020 0x00000900 0x00000600	;# AFRL
+
+	mww 0xA0001030 0x00001000				;# QUADSPI_LPTR: deactivate CS after 4096 clocks when FIFO is full
+	mww 0xA0001000 0x03500008				;# QUADSPI_CR: PRESCALER=3, APMS=1, FTHRES=0, FSEL=0, DFM=0, SSHIFT=0, TCEN=1
+	mww 0xA0001004 0x00170100				;# QUADSPI_DCR: FSIZE=0x17, CSHT=0x01, CKMODE=0
+	mmw 0xA0001000 0x00000001 0				;# QUADSPI_CR: EN=1
+
+	# 1-line spi mode
+	mww 0xA0001014 0x000003F5				;# QUADSPI_CCR: FMODE=0x0, DMODE=0x0, DCYC=0x0, ADSIZE=0x0, ADMODE=0x0, IMODE=0x3, INSTR=RSTQIO
+	sleep 1
+
+	# memory-mapped read mode with 3-byte addresses
+	mww 0xA0001014 0x0D002503				;# QUADSPI_CCR: FMODE=0x3, DMODE=0x1, DCYC=0x0, ADSIZE=0x2, ADMODE=0x1, IMODE=0x1, INSTR=READ
+}
+
+$_TARGETNAME configure -event reset-init {
+	mww 0x40023C00 0x00000006				;# 6 WS for 192 MHz HCLK
+	sleep 1
+	mww 0x40023804 0x24003008				;# 192 MHz: PLLM=8, PLLN=192, PLLP=2
+	mww 0x40023808 0x00009400				;# APB1: /4, APB2: /2
+	mmw 0x40023800 0x01000000 0x00000000	;# PLL on
+	sleep 1
+	mmw 0x40023808 0x00000002 0x00000000	;# switch to PLL
+	sleep 1
+
+	adapter speed 4000
+
+	qspi_init
+}


### PR DESCRIPTION
Closes [#3](https://github.com/Blargian/sound_localization/issues/3). 

**Issue**

Program builds and runs fine but when using debugger (OpenOCD) gets stuck in the error_handler here:

https://github.com/Blargian/sound_localization/blob/c09c756e3b353843f87f858970ce57cab98f6b41/firmware/sound_localizer/Core/Src/main.c#L280-L283

Why? This [post](https://community.st.com/t5/stm32-mcus-touchgfx-and-gui/clock-config-fails-if-using-debug-and-external-loader-hal-rcc/td-p/96894) explains it nicely but basically PLL cannot be accessed once it has been changed already, so OpenOCD sets up the clock it needs with HSI and PLL and then when `HAL_RCC_OscConfig` gets called again during initialization PLL settings do not match so it throws a `HAL_ERROR`.

**Solution**

It is necessary to add 

```c
RCC->CFGR=0;
```

This sets clock source to HSI with no PLL. If HSI with PLL is already set (as it is with OpenOCD) then the application only checks PLL and fails if the PLL settings mismatch (OpenOCD uses 48MHz clock).